### PR TITLE
ci(release): set node v.18 as input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       prereleaseTag: ${{ inputs.prereleaseTag }}
       build-output-dir: lib
+      node-version: "18"
     secrets:
       NPM_PUBLISH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
     permissions:


### PR DESCRIPTION
Before: https://github.com/Parsimotion/notification-processor/actions/runs/17594334902/job/49982816053

After: https://github.com/Parsimotion/notification-processor/actions/runs/17595102769/job/49985389148